### PR TITLE
Add generic Base View

### DIFF
--- a/MyFuture/MyFuture/settings.py
+++ b/MyFuture/MyFuture/settings.py
@@ -45,7 +45,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
+    # 'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/MyFuture/MyFuture/urls.py
+++ b/MyFuture/MyFuture/urls.py
@@ -5,5 +5,5 @@ from mainApp import views
 
 urlpatterns = [
     url(r'^$', TemplateView.as_view(template_name='index.html'), name='home'),
-    url(r'^api/crawl/', views.crawl, name='crawl'),
+    url(r'^api/crawl/', views.CrawlView.as_view(), name='crawl'),
 ]

--- a/MyFuture/mainApp/models.py
+++ b/MyFuture/mainApp/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/MyFuture/mainApp/views/__init__.py
+++ b/MyFuture/mainApp/views/__init__.py
@@ -1,0 +1,2 @@
+from .crawl_view import CrawlView
+from .app_view import AppView

--- a/MyFuture/mainApp/views/app_view.py
+++ b/MyFuture/mainApp/views/app_view.py
@@ -1,0 +1,22 @@
+from django.views import View
+from django.http import JsonResponse, HttpResponse
+from pdb import set_trace as st
+
+class AppView(View):
+    default_headers = {
+        'content_type': 'application/json',
+        'farlompa': 'ne'
+    }
+
+    # TODO: Cambiar json a un metodo de clase en vez de instancia
+    def json(self, body, status=200, headers=None):
+        if not headers:
+            headers = AppView.default_headers
+        return JsonResponse(body,
+                            status=422,
+                            headers=AppView.default_headers)
+
+    def missing_arguments_response(self, missing_arguments = None):
+        if missing_arguments:
+            pass
+        return self.json({'error': 'Missing arguments'})

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,2 @@
+# CSRF verification failed. Request aborted.
+Cuando haces un post sin cookies te tira est error. Termine quitandole un middleware para arreglarlo: # 'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
Cleans up a bit the project.
The new Base view is meant to have the generic responses for all future endpoints. Any other logic which is common to all views is eligible to be here as well;